### PR TITLE
Code refactoring of bar_chart(), syntax highlight enabling in readme.md and modification of .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 .Rhistory
 .Rproj.user
 lotOfCells.Rproj
+LotOfCells.Rproj
 

--- a/R/bar_chart.R
+++ b/R/bar_chart.R
@@ -190,6 +190,7 @@ bar_chart <- function(scObject=NULL, main_variable=NULL, subtype_variable=NULL, 
     plot_subtitle <- paste("Class:", subtype_only)
     scale_y_continuous_limits <- c(-0.1, 1)
     legend.position <- "none"
+    colors_use <- colores
   } else {
     annotate_ymin <- -0.02
     annotate_ymax <- -0.06
@@ -197,6 +198,7 @@ bar_chart <- function(scObject=NULL, main_variable=NULL, subtype_variable=NULL, 
     plot_subtitle <- ifelse(!is.null(sample_id), paste("Individual Sub-level by:", sample_id), "")
     scale_y_continuous_limits <- NULL
     legend.position <- NULL
+    colors_use <- colores[colorOrder]
   }
   
   g <- ggplot2::ggplot(data = contig_tab_resh,
@@ -217,7 +219,7 @@ bar_chart <- function(scObject=NULL, main_variable=NULL, subtype_variable=NULL, 
        ggplot2::labs(title = paste("Proportions of", subtype_variable, "by", main_variable),
                      subtitle = plot_subtitle) +
        ggplot2::scale_fill_manual(name = "covariable", 
-                                  values = if(!is.null(subtype_only)){colores} else {colores[colorOrder]}, 
+                                  values = colors_use, 
                                   drop = FALSE) +
        ggplot2::annotate(ymin = annotate_ymin, 
                          ymax = annotate_ymax,

--- a/R/bar_chart.R
+++ b/R/bar_chart.R
@@ -42,68 +42,110 @@ bar_chart <- function(scObject=NULL, main_variable=NULL, subtype_variable=NULL, 
   order <- names(sort(table(covariable),decreasing = FALSE))
   colorOrder <- rev(seq(1, length(order)))
   names(colorOrder) <- order
-
-  if(!is.null(sample_id)){
-    # Independent sample/factor have been specified:
+  
+  # Define common Y scale breaks, minor breaks and labels.
+  breaks_use <- seq(from = 0, to = 1, by = 0.1)
+  minor_breaks_use <- seq(from = 0.05, to = 0.95, by = 0.1)
+  labels_use <- seq(from = 0, to = 100, by = 10)
+  
+  if (!is.null(sample_id)){
+    # Independent sample/factor has been specified:
     samples <- as.character(main_metadata[, sample_id])
     n.of.stack.bars <- table(unique(data.frame(groups, samples))$groups)
     names(n.of.stack.bars) <- names(table(unique(data.frame(groups, samples))$groups))
     groupSorting <- data.frame(groups, samples)
     groupSorting <- unique(groupSorting)
-    levelsOrdered <- apply(groupSorting[order(groupSorting$groups),], 1, function(sortedElements)paste(sortedElements[1], sortedElements[2], sep="_"))
+    levelsOrdered <- apply(groupSorting[order(groupSorting$groups),], 1, function(sortedElements){paste(sortedElements[1], sortedElements[2], sep="_")})
     ### IN PROGRESS - CONTRIBUTION
-    if(contribution){
-      colores <- getPalette(usePalette=colors, nColors=length(colorOrder))
+    if (contribution){
+      # Contribution plot has been specified:
+      
+      # Generate color palette.
+      colores <- getPalette(usePalette = colors, 
+                            nColors = length(colorOrder))
       colores <- rev(colores)
       names(colores) <- names(colorOrder)
-      empty_plot <- ggplot(data.frame(x = 1, y = factor(names(colores), levels = names(colores))), aes(x, y, fill = y)) +
-        geom_bar(position="stack", stat="identity") +
-        scale_fill_manual(values = colores) +
-        ggplot2::guides(fill = guide_legend(title=paste("Class:", subtype_variable), drop=FALSE))
-      plot_table <- ggplot2::ggplot_gtable(ggplot_build(empty_plot))
-      legend_plot <- which(sapply(plot_table$grobs, function(x) x$name) == "guide-box")
+      
+      # Generate empty plot.
+      empty_plot <- ggplot2::ggplot(data = data.frame(x = 1, 
+                                                      y = factor(names(colores), 
+                                                                 levels = names(colores))), 
+                                    mapping = ggplot2::aes(x = x, 
+                                                           y = y, 
+                                                           fill = y)) +
+                    ggplot2::geom_bar(position = "stack", 
+                                      stat = "identity") +
+                    ggplot2::scale_fill_manual(values = colores) +
+                    ggplot2::guides(fill = ggplot2::guide_legend(title = paste("Class:", subtype_variable), 
+                                                                 drop = FALSE))
+      plot_table <- ggplot2::ggplot_gtable(ggplot2::ggplot_build(empty_plot))
+      legend_plot <- which(sapply(plot_table$grobs, function(x){x$name}) == "guide-box")
       legend <- plot_table$grobs[[legend_plot]]
-      tmp <- data.frame(original=groups, groups=paste(groups, samples, sep = "_"), covariable) %>% group_split(original)
-      tmp <- lapply(tmp, function(main_group){
-        df <- data.frame(original=unique(main_group$original), reshape2::melt(table(main_group$groups,main_group$covariable)))
-        df$value <- df$value/sum(df$value)
-        df$colores <- NA
-        color_range <- log2(length(unique(df$Var1)))/8 # Darkening and lightening factor depending on n of samples
-        for (aColor in colores){
-          aName <- names(colores)[colores %in% aColor]
-          df$colores[df$Var2 %in% aName] <- c(grDevices::colorRampPalette(bias=0.5, colors=c(colorspace::lighten(aColor, color_range),
-                                                                                     colorspace::darken(aColor, color_range)))(length(unique(df$Var1))))
-        }
-        return(df)
-        })
+      
+      tmp <- data.frame(original = groups, 
+                        groups = paste(groups, samples, sep = "_"), covariable) %>% 
+             dplyr::group_split(original)
+      
+      tmp <- lapply(tmp, function(main_group){df <- data.frame(original = unique(main_group$original), 
+                                                               reshape2::melt(table(main_group$groups, main_group$covariable)))
+                                              df$value <- df$value / sum(df$value)
+                                              df$colores <- NA
+                                              color_range <- log2(length(unique(df$Var1))) / 8 # Darkening and lightening factor depending on n of samples
+                                              for (aColor in colores){aName <- names(colores)[colores %in% aColor]
+                                                                      colors_use <- c(colorspace::lighten(aColor, color_range),
+                                                                                      colorspace::darken(aColor, color_range))
+                                                                      df$colores[df$Var2 %in% aName] <- c(grDevices::colorRampPalette(bias = 0.5, 
+                                                                                                                                      colors = colors_use)(length(unique(df$Var1))))}
+                                              return(df)})
+      
       contig_tab_resh <- do.call(rbind, tmp)
       colnames(contig_tab_resh) <- c("groups", "per_group", "covariable", "value", "colores")
+      
       # Plot Bars
       contig_tab_resh[,"covariable"] <- factor(contig_tab_resh[,"covariable"], levels = order)
       contig_tab_resh$supra <- paste(contig_tab_resh$per_group, contig_tab_resh$covariable, sep = "_")
       colores <- contig_tab_resh$colores
       names(colores) <- contig_tab_resh$supra
-      new_order <- unlist(lapply(names(colorOrder), function(type)contig_tab_resh$supra[contig_tab_resh$covariable %in% type]))
+      new_order <- unlist(lapply(names(colorOrder), function(type){contig_tab_resh$supra[contig_tab_resh$covariable %in% type]}))
       contig_tab_resh$supra <- factor(contig_tab_resh$supra, levels = new_order)
-      g <- ggplot2::ggplot(contig_tab_resh, ggplot2::aes(x=groups, y=value, group_by=supra, fill = supra)) +
-        ggplot2::geom_bar(position="stack", stat="identity", linewidth=NA) +
-        ggplot2::theme_minimal() +
-        ggplot2::theme(axis.text.x=ggplot2::element_text(angle=45, vjust=1, hjust=1,size = 12)) +
-        ggplot2::scale_fill_manual("supra", values = colores, drop=FALSE) +
-        ggplot2::ggtitle(paste("Proportions of", subtype_variable, "by", main_variable), paste("Contribution by",sample_id)) +
-        ggplot2::scale_y_continuous(name="percentage", breaks =  seq(0, 1, by=0.1), minor_breaks = seq(0.05, 0.95, by=0.1), labels = seq(0, 100, by=10)) +
-        ggplot2::theme(legend.position = "none")
-      g <- gridExtra::arrangeGrob(g, legend, nrow=1, widths=c(0.7,0.2))
+      
+      # Generate the plot.
+      g <- ggplot2::ggplot(data = contig_tab_resh, 
+                           mapping = ggplot2::aes(x = groups, 
+                                                  y = value, 
+                                                  group_by = supra, 
+                                                  fill = supra)) +
+           ggplot2::geom_bar(position = "stack", 
+                             stat = "identity", 
+                             linewidth = NA) +
+           ggplot2::theme_minimal() +
+           ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 45, 
+                                                              vjust = 1, 
+                                                              hjust = 1, 
+                                                              size = 12)) +
+           ggplot2::scale_fill_manual(name = "supra", 
+                                      values = colores, 
+                                      drop = FALSE) +
+           ggplot2::labs(title = paste("Proportions of", subtype_variable, "by", main_variable), 
+                         subtitle = paste("Contribution by", sample_id)) +
+           ggplot2::scale_y_continuous(name = "percentage", 
+                                       breaks =  breaks_use, 
+                                       minor_breaks = minor_breaks_use, 
+                                       labels = labels_use) +
+           ggplot2::theme(legend.position = "none")
+      
+      g <- gridExtra::arrangeGrob(g, legend, nrow = 1, widths = c(0.7,0.2))
       return(ggpubr::as_ggplot(g))
       ### IN PROGRESS - CONTRIBUTION
-    }else{
-      # No contribution ploting
-      df <- data.frame(groups=paste(groups, samples, sep = "_"), covariable)
+    } else {
+      # No contribution plotting is specified:
+      df <- data.frame(groups = paste(groups, samples, sep = "_"), covariable)
       contig_tab <- apply(table(df), 1, function(row){row/sum(row)})
       group_names <- colnames(contig_tab)
-      colores <- getPalette(usePalette=colors, nColors = length(colorOrder))
+      colores <- getPalette(usePalette = colors, 
+                            nColors = length(colorOrder))
     }
-  }else{
+  } else {
     # No independent sample/factor specified:
     df <- data.frame(groups, covariable)
     levelsOrdered <- levels(groups)
@@ -113,6 +155,7 @@ bar_chart <- function(scObject=NULL, main_variable=NULL, subtype_variable=NULL, 
     group_names <- colnames(contig_tab)
     colores <- getPalette(usePalette=colors, nColors = length(colorOrder))
   }
+  
   # Plot Bars
   contig_tab_resh <- reshape2::melt(contig_tab)
   contig_tab_resh[,"covariable"] <- factor(contig_tab_resh[,"covariable"], levels = order)
@@ -120,13 +163,15 @@ bar_chart <- function(scObject=NULL, main_variable=NULL, subtype_variable=NULL, 
   xmin.annotation <- c(0.5, cumsum(n.of.stack.bars)[1:length(n.of.stack.bars)-1]+0.5)
   xmax.annotation <- c(cumsum(n.of.stack.bars)[1:length(n.of.stack.bars)])+0.5
   annot.data <- data.frame(x=xmin.annotation, y=xmax.annotation, group=factor(names(n.of.stack.bars)))
-  if(length(n.of.stack.bars) > 8){
+  
+  if (length(n.of.stack.bars) > 8){
     group_colores <- grDevices::colorRampPalette(colors = ggplot2::alpha(colour = RColorBrewer::brewer.pal(8, "Set2"), alpha = 0.8))(length(n.of.stack.bars))
     group_colores = colorspace::desaturate(col = group_colores, amount = 0.16)
-  } else{
+  } else {
     group_colores <- suppressWarnings(ggplot2::alpha(colour = RColorBrewer::brewer.pal(length(n.of.stack.bars), "Set2"), alpha = 0.8))[1:length(n.of.stack.bars)]
     group_colores = colorspace::desaturate(col = group_colores, amount = 0.16)
   }
+  
   if(!is.null(subtype_only)){
     groupForColors <- table(unlist(lapply(strsplit(x = group_names, split = "_"), function(group)group[1])))
     contig_tab_resh <- contig_tab_resh[contig_tab_resh[,"covariable"] %in% subtype_only, ]
@@ -136,57 +181,62 @@ bar_chart <- function(scObject=NULL, main_variable=NULL, subtype_variable=NULL, 
     coloresSubtype <- rev(coloresSubtype)
     colores <- rep(coloresSubtype, groupForColors)
   }
-  if(!is.null(subtype_only)){
-    g <- ggplot2::ggplot(contig_tab_resh, ggplot2::aes(x=groups, y=value, group_by=covariable, fill = groups)) +
-      ggplot2::geom_bar(position="stack", stat="identity") +
-      ggplot2::theme_minimal() +
-      ggplot2::theme(axis.text.x=ggplot2::element_text(angle=45, vjust=1, hjust=1,size = 12)) +
-      ggplot2::guides(fill = guide_legend(title=paste("Class:", subtype_variable), drop=FALSE)) +
-      ggplot2::scale_fill_manual("covariable", values = colores, drop=FALSE) +
-      ggplot2::ggtitle(paste("Proportions of", subtype_variable, "by", main_variable), paste("Class:",subtype_only)) +
-      ggplot2::scale_y_continuous(name="percentage", breaks=seq(0, 1, by=0.1), minor_breaks = seq(0.05, 0.95, by=0.1),
-                                  labels = seq(0, 100, by=10), limits = c(-0.1, 1)) +
-      ggplot2::annotate(
-        ymin = -0.02, ymax = -0.08,
-        xmin = xmin.annotation,
-        xmax = xmax.annotation,
-        geom = "rect",
-        fill = rev(group_colores)
-      ) +
-      ggplot2::annotate(
-        y = -0.05,
-        x = rowMeans(annot.data[,c("x","y")]),
-        geom = "text", label=annot.data$group,
-        color="white", fontface = "italic", size=4
-      ) + ggplot2::theme(legend.position = "none")
-
-  }else{
-    g <- ggplot2::ggplot(contig_tab_resh, ggplot2::aes(x=groups, y=value, group_by=covariable, fill = covariable)) +
-        ggplot2::geom_bar(position="stack", stat="identity") +
-        ggplot2::theme_minimal() +
-        ggplot2::theme(axis.text.x=ggplot2::element_text(angle=45, vjust=1, hjust=1,size = 12)) +
-        ggplot2::guides(fill = guide_legend(title=paste("Class:", subtype_variable), drop=FALSE)) +
-        ggplot2::scale_fill_manual("covariable", values = colores[colorOrder], drop=FALSE) +
-        ggplot2::ggtitle(paste("Proportions of", subtype_variable, "by", main_variable)) +
-        ggplot2::scale_y_continuous(name="percentage", breaks =  seq(0, 1, by=0.1), minor_breaks = seq(0.05, 0.95, by=0.1), labels = seq(0, 100, by=10)) +
-        ggplot2::annotate(
-          ymin = -0.02, ymax = -0.06,
-          xmin = xmin.annotation,
-          xmax = xmax.annotation,
-          geom = "rect",
-          fill = rev(group_colores)
-        ) +
-        ggplot2::annotate(
-          y = -0.04,
-          x = rowMeans(annot.data[,c("x","y")]),
-          geom = "text", label=annot.data$group,
-          color="white", fontface = "bold.italic", size=4
-        )
-    if(!is.null(sample_id)){
-      g <- g + ggplot2::ggtitle(paste("Proportions of", subtype_variable, "by", main_variable), paste("Individual Sub-level by:", sample_id))
-    } else{
-      g <- g + ggplot2::ggtitle(paste("Proportions of", subtype_variable, "by", main_variable))
-    }
+  
+  # Plot settings:
+  if (!is.null(subtype_only)){
+    annotate_ymin <- -0.02
+    annotate_ymax <- -0.08
+    annotate_y <- -0.05
+    plot_subtitle <- paste("Class:", subtype_only)
+    scale_y_continuous_limits <- c(-0.1, 1)
+    legend.position <- "none"
+  } else {
+    annotate_ymin <- -0.02
+    annotate_ymax <- -0.06
+    annotate_y <- -0.04
+    plot_subtitle <- ifelse(!is.null(sample_id), paste("Individual Sub-level by:", sample_id), "")
+    scale_y_continuous_limits <- NULL
+    legend.position <- NULL
   }
+  
+  g <- ggplot2::ggplot(data = contig_tab_resh,
+                       mapping = ggplot2::aes(x = groups,
+                                              y = value,
+                                              group_by = covariable,
+                                              fill = if (!is.null(subtype_only)){groups} else {covariable})) + 
+       ggplot2::geom_bar(position = "stack",
+                         stat = "identity") + 
+       ggplot2::theme_minimal() +
+       ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 45, 
+                                                          vjust = 1, 
+                                                          hjust = 1, 
+                                                          size = 12),
+                      legend.position = legend.position) +
+       ggplot2::guides(fill = ggplot2::guide_legend(title = paste("Class:", subtype_variable), 
+                                                    drop = FALSE)) + 
+       ggplot2::labs(title = paste("Proportions of", subtype_variable, "by", main_variable),
+                     subtitle = plot_subtitle) +
+       ggplot2::scale_fill_manual(name = "covariable", 
+                                  values = if(!is.null(subtype_only)){colores} else {colores[colorOrder]}, 
+                                  drop = FALSE) +
+       ggplot2::annotate(ymin = annotate_ymin, 
+                         ymax = annotate_ymax,
+                         xmin = xmin.annotation,
+                         xmax = xmax.annotation,
+                         geom = "rect",
+                         fill = rev(group_colores)) +
+       ggplot2::annotate(y = annotate_y,
+                         x = rowMeans(annot.data[,c("x","y")]),
+                         geom = "text", 
+                         label = annot.data$group,
+                         color = "white", 
+                         fontface = "italic", 
+                         size = 4) +
+       ggplot2::scale_y_continuous(name = "percentage", 
+                                   breaks = breaks_use, 
+                                   minor_breaks = minor_breaks_use,
+                                   labels = labels_use, 
+                                   limits = scale_y_continuous_limits)
+     
   return(g)
 }

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Proportion test statistics and visualization on single cell metadata. A simple p
 
 The package can be installed from R software using devtools:
 
-```{r eval=FALSE}
+```r
 library(devtools)
 install_github("OscarGVelasco/lotOfCells")
 ```

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ All functions require the following inputs:
 
 We will construct a simulated dataset of single-cell metadata consisting of six samples with two conditions (mutant and wild type), including four cell types (A, B, C, D) and different time points simulating treatment (time 0h, 2h, 4h):
 
-```{r construct}
+```r
 
 # # Data simulation with 2 conditions, 3 time points, and 4 cell-types:
 sample1 <- c(rep("CellTypeA",700),rep("CellTypeB",300),rep("CellTypeC",500),rep("CellTypeD",1000))
@@ -81,7 +81,7 @@ Barplots are displayed in such an order that the class with the largest average 
 
 `LotOfCells` can be used with any other combination of variables (different from cell type). Here (Figure D), by switching the `subtype_variable` to the time-points we can investigate the contribution of time-points to the main condition, serving as a quality check to understand the weight of some covarites to the target condition (e.g. time points, sequencing dates or different tissues):
 
-```{r, eval=False }
+```r
 # # Test of barplot charts:
 # All cells together for every group:
 g.A <- bar_chart(meta.data, main_variable = "condition", subtype_variable = "cell_type")
@@ -108,7 +108,7 @@ ggpubr::ggarrange(g.A, g.B, g.C, g.D, labels = c("A", "B", "C","D"),
 
 If we want to visualize the contribution to the global proportion of a specific class (e.g.: how much each sample contribute to each cell type proportion), we can use the `contribution = TRUE` flag when setting the `sample_id` variable:
 
-```{r}
+```r
 # Examine the contribution of each sample to the proportions of cell types per condition:
 g.A <- bar_chart(meta.data, main_variable = "condition",subtype_variable = "cell_type",
                  sample_id = "sample", contribution = TRUE)
@@ -129,7 +129,7 @@ ggpubr::ggarrange(g.A, g.B, labels = c("A", "B"),
 
 To visualize small proportions using waffle plots might be more advisable:
 
-```{r}
+```r
 # # Test of Waffles charts:
 # All cells together for every group
 g.A <- waffle_chart(meta.data, main_variable = "condition", subtype_variable = "cell_type")
@@ -156,7 +156,7 @@ ggpubr::ggarrange(g.B, g.A, g.C, g.D, labels = c("A", "B", "C", "D"),
 
 To visualize numeric values (including gene/feature expression) over groups and sub-categories, we can make use of density ridge plots to observe its data distribution. We have to select the variable to use in `numerical_variable`.
 
-```{r}
+```r
 # # Test of density charts:
 # simulate the number of RNA features detected in each cell:
 meta.data <- rbind.data.frame(meta.data %>% dplyr::filter(condition == "mut") %>% 
@@ -182,7 +182,7 @@ ggpubr::ggarrange(g.A, g.B, labels = c("A", "B"),
 
 If `scObject` is of class `Seurat` or `SingleCellExperiment`, we can specify a gene/feature name directly in `subtype_variable` to display the counts per class and sub-level. Here we show an example using human pancreas single-cell data (Baron M et al. (2017) using the scRNAseq R package), the gene SST is a marker of pancreatic $\delta cells:
 
-```{r eval=FALSE}
+```r
 # # Test of density charts:
 density_chart(scObject = sc_pancreas_human, main_variable = "donor", subtype_variable = "cell.type", 
               numerical_variable = "SST")
@@ -199,7 +199,7 @@ density_chart(scObject = sc_pancreas_human, main_variable = "donor", subtype_var
 
 Colors can be easily changed for bar, waffle, or polar plots using the `colors` option. To do this, simply provide a vector of colors to use. If the specified colors are insufficient, a palette will be created using colorRampPalette based on the colors specified. If no colors are specified, the default color palette of LotOfCells will be used.
 
-```{r}
+```r
 # # Using different colors:
 # We can use RColorBrewer to easily obtain a different palette of colors:
 g.A <- bar_chart(meta.data, main_variable = "condition", subtype_variable = "cell_type", 
@@ -219,7 +219,7 @@ ggpubr::ggarrange(g.A, g.B, labels = c("A", "B"), ncol=2, nrow=1, widths = c(0.4
 
 Lastly, this visualization might be interesting to compare raw number of cells per class (e.g.: if a sample has a much larger number of cells, which might affect downstream analysis).
 
-```{r}
+```r
 # Test of circle polar plot:
 polar_chart(meta.data, main_variable = "condition",subtype_variable = "cell_type", sample_id = "sample")
 # Test of polar plot by cell-type:
@@ -230,7 +230,7 @@ polar_chart(meta.data, main_variable = "cell_type",subtype_variable = "sample")
 
 For the proportion tests and the Montecarlo simulations that we are going to introduce, we can use parallelization using `BiocParallel`:
 
-```{r}
+```r
 # Set number of CPUs to use:
 BiocParallel::register(BPPARAM =  BiocParallel::MulticoreParam(workers = 6))
 ```
@@ -243,7 +243,7 @@ The main feature of LotOfCells is the testing of differences in proportions, com
 
 A plot of the differences in proportions is generated, with pink shades representing the standard deviation of the Monte Carlo simulations, and a dataframe containing the statistical results is returned.
 
-```{r}
+```r
 # # Test of 2 conditions using montecarlo and differences in percentage
 labelOrder <- c("mut","wt")
 results.2.conditions <- lotOfCells(scObject = meta.data,
@@ -267,7 +267,7 @@ To determine if the majority of class proportions change significantly simultane
 
 Higher divergence scores suggest more significant simultaneous changes in class proportions between the two conditions.
 
-```{r}
+```r
 # # Test of entropy for 2 conditions using montecarlo simulation
 labelOrder <- c("mut","wt")
 results.2.conditions.entropy <- entropyScore(scObject = meta.data,
@@ -287,7 +287,7 @@ results.2.conditions.entropy <- entropyScore(scObject = meta.data,
 
 The test of differences in proportions available in LotOfCells can be done with more than 2 conditions, by computing a Kendall rank correlation coefficient. To compare the proportions of a specific class between several conditions we will need to define the classes and the order in which they will be compared from the column specified in `main_variable`, the correlation (positive and negative) will be tested following the order defined. Optionally, like introduced above, we can set the sample_id column (or other sub-class level) to include the per-sample heterogeneity in the computational simulation.
 
-```{r}
+```r
 # # Test of correlation for SEVERAL conditions using Kendall rank correlation
 labelOrder <- c("time 0h","time 2h","time 4h")
 results.3.conditions <- lotOfCells(scObject = meta.data,


### PR DESCRIPTION
Hi @OscarGVelasco,

I would like to contribute to your R package!

As a starters, I enabled syntax highlight in the `readme.md` file, so that examples are colored based on R syntax highlight.

Also, added `LotOfCells.Rproj` to `.gitignore`, as it was missing (there is a similar entry with lowercase letters, perhaps from a previous repo name?). Either way, this should prevent the `.Rproj` files to get committed into the repo.

Furthermore, I have applied some refactoring in the `bar_chart()` function:
- Added `ggplot2::` prefixes in functions that were being called directly.
- Standardized the use of spaces before and after equals.
- Standardized the use of `one parameter per line` in most cases, with the exception of those where the readability would be affected.
- Standardized the use of parameter names across functions, instead of providing the values only.
- With the exception of contribution plotting, I have merged the ggplot2 calls into a single one, as it was heavily redundant. Differential parameters between the use of `subtype_only` and not are now collected prior to the `ggplot2::ggplot()` call. This way, the plotting becomes more modular, as parameters that are different across cases can be collected before the call. **TO DO**: Refactor the plotting when `contributions` are desired, as this happens way before in the code and seems to be a complete independent case altogether.

The modifcations have been tested using the simulation dataset:
```r
# # Data simulation with 2 conditions, 3 time points, and 4 cell-types:
sample1 <- c(rep("CellTypeA",700),rep("CellTypeB",300),rep("CellTypeC",500),rep("CellTypeD",1000))
sample2 <- c(rep("CellTypeA",1700),rep("CellTypeB",350),rep("CellTypeC",550),rep("CellTypeD",800))
sample3 <- c(rep("CellTypeA",1200),rep("CellTypeB",200),rep("CellTypeC",420),rep("CellTypeD",800))
sample4 <- c(rep("CellTypeA",500),rep("CellTypeB",1000),rep("CellTypeC",10),rep("CellTypeD",1200))
sample5 <- c(rep("CellTypeA",550),rep("CellTypeB",990),rep("CellTypeC",10),rep("CellTypeD",1100))
sample6 <- c(rep("CellTypeA",1350),rep("CellTypeB",590),rep("CellTypeC",300),rep("CellTypeD",600))
sample <- c(rep("A",length(sample1)),rep("B",length(sample2)),rep("C",length(sample3)),rep("D",length(sample4)),rep("E",length(sample5)),rep("F",length(sample6)))
times <- c(rep("time 0h",length(sample1)),rep("time 0h",length(sample2)),rep("time 2h",length(sample3)),rep("time 2h",length(sample4)),rep("time 4h",length(sample5)),rep("time 4h",length(sample6)))
cell_type <- c(sample1, sample2, sample3, sample4, sample5, sample6)
meta.data <- data.frame(sample, cell_type, times)
meta.data$condition <- "wt"
meta.data[meta.data$sample %in% c("B","D","F"),]$condition <- "mut"
rownames(meta.data) <- as.character(1:nrow(meta.data))
head(meta.data)
```

And the example use cases:

```r
# # Test of barplot charts:
# All cells together for every group:
g.A <- bar_chart(meta.data, main_variable = "condition", subtype_variable = "cell_type")
# Barplot for each individual sample:
g.B <- bar_chart(meta.data, main_variable = "condition",subtype_variable = "cell_type",
                 sample_id = "sample")
# Display One-Class only:
g.C <- bar_chart(meta.data, main_variable = "condition",subtype_variable = "cell_type",
                 sample_id = "sample", subtype_only = "CellTypeD")
# Distribution of time-points by condition:
g.D <- bar_chart(meta.data, main_variable = "condition",subtype_variable = "times")

ggpubr::ggarrange(g.A, g.B, g.C, g.D, labels = c("A", "B", "C","D"),
                  ncol=2, nrow=2, common.legend = F)
```

This resulted in identical figures from the ones in the examples.

Let me know if this was helpful and happy to keep collaborating in the future!
Enrique